### PR TITLE
adds sample ratio ENV to tracing example

### DIFF
--- a/tracing/docker-compose.yaml
+++ b/tracing/docker-compose.yaml
@@ -18,6 +18,7 @@ services:
       - "SPICEDB_NS_CACHE_METRICS=true"
       - "SPICEDB_METRICS_ENABLED=true"
       - "SPICEDB_OTEL_PROVIDER=otlpgrpc"
+      - "SPICEDB_OTEL_SAMPLE_RATIO=1"
       - "OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317"
     depends_on:
       - "otel-collector"


### PR DESCRIPTION
we recenly changed the default for this flag,
and so for an example it would be a bit frustrating that requests are not showing up because of the default low sampling ratio