### PR TITLE
Update Dedicated metrics example

### DIFF
--- a/authzed-dedicated-metrics/otel-collector/env-vars.sh
+++ b/authzed-dedicated-metrics/otel-collector/env-vars.sh
@@ -1,3 +1,4 @@
+export AUTHZED_DEDICATED_HOST='<your-authzed-dashboard-url>'
 export PROMETHEUS_USERNAME='<permission-system-name>'
 export PROMETHEUS_PASSWORD='<permission-system-token>'
 export OTEL_EXPORTER_OTLP_ENDPOINT="https://<metrics-service-url>:443"

--- a/authzed-dedicated-metrics/otel-collector/otel-collector-config.yaml
+++ b/authzed-dedicated-metrics/otel-collector/otel-collector-config.yaml
@@ -7,7 +7,7 @@ receivers:
           metrics_path: "/api/v1alpha/metrics"
           scrape_interval: "15s"
           static_configs:
-            - targets: ["app.admin.demo.aws.authzed.net"]
+            - targets: ["${AUTHZED_DEDICATED_HOST}"]
           basic_auth:
             username: ${PROMETHEUS_USERNAME}  # yamllint disable-line rule:quoted-strings
             password: ${PROMETHEUS_PASSWORD}  # yamllint disable-line rule:quoted-strings


### PR DESCRIPTION
Use an environment variable for the target endpoint so that customers can easily override it for their own setup.