### PR TITLE
rewrite google IAM example to use self relations instead of wildcards

### DIFF
--- a/schemas/google-iam/README.md
+++ b/schemas/google-iam/README.md
@@ -10,204 +10,201 @@ Models the permissions of Google's Cloud IAM in SpiceDB. Blog post: https://auth
 definition user {}
 
 definition role {
-    relation spanner_databaseoperations_cancel: user:*
-    relation spanner_databaseoperations_delete: user:*
-    relation spanner_databaseoperations_get: user:*
-    relation spanner_databaseoperations_list: user:*
-    relation spanner_databaseroles_list: user:*
-    relation spanner_databaseroles_use: user:*
-    relation spanner_databases_beginorrollbackreadwritetransaction: user:*
-    relation spanner_databases_beginpartitioneddmltransaction: user:*
-    relation spanner_databases_beginreadonlytransaction: user:*
-    relation spanner_databases_create: user:*
-    relation spanner_databases_drop: user:*
-    relation spanner_databases_get: user:*
-    relation spanner_databases_getddl: user:*
-    relation spanner_databases_getiampolicy: user:*
-    relation spanner_databases_list: user:*
-    relation spanner_databases_partitionquery: user:*
-    relation spanner_databases_partitionread: user:*
-    relation spanner_databases_read: user:*
-    relation spanner_databases_select: user:*
-    relation spanner_databases_setiampolicy: user:*
-    relation spanner_databases_update: user:*
-    relation spanner_databases_updateddl: user:*
-    relation spanner_databases_userolebasedaccess: user:*
-    relation spanner_databases_write: user:*
-    relation spanner_instances_get: user:*
-    relation spanner_instances_getiampolicy: user:*
-    relation spanner_instances_list: user:*
-    relation spanner_sessions_create: user:*
-    relation spanner_sessions_delete: user:*
-    relation spanner_sessions_get: user:*
-    relation spanner_sessions_list: user:*
-}
+    relation bound_user: user
+    
+    relation spanner_databaseoperations_cancel: role
+    relation spanner_databaseoperations_delete: role
+    relation spanner_databaseoperations_get: role
+    relation spanner_databaseoperations_list: role
+    relation spanner_databaseroles_list: role
+    relation spanner_databaseroles_use: role
+    relation spanner_databases_beginorrollbackreadwritetransaction: role
+    relation spanner_databases_beginpartitioneddmltransaction: role
+    relation spanner_databases_beginreadonlytransaction: role
+    relation spanner_databases_create: role
+    relation spanner_databases_drop: role
+    relation spanner_databases_get: role
+    relation spanner_databases_getddl: role
+    relation spanner_databases_getiampolicy: role
+    relation spanner_databases_list: role
+    relation spanner_databases_partitionquery: role
+    relation spanner_databases_partitionread: role
+    relation spanner_databases_read: role
+    relation spanner_databases_select: role
+    relation spanner_databases_setiampolicy: role
+    relation spanner_databases_update: role
+    relation spanner_databases_updateddl: role
+    relation spanner_databases_userolebasedaccess: role
+    relation spanner_databases_write: role
+    relation spanner_instances_get: role
+    relation spanner_instances_getiampolicy: role
+    relation spanner_instances_list: role
+    relation spanner_sessions_create: role
+    relation spanner_sessions_delete: role
+    relation spanner_sessions_get: role
+    relation spanner_sessions_list: role
 
-definition role_binding {
-    relation user: user
-    relation role: role
-
-    permission spanner_databaseoperations_cancel = user & role->spanner_databaseoperations_cancel
-    permission spanner_databaseoperations_delete = user & role->spanner_databaseoperations_delete
-    permission spanner_databaseoperations_get = user & role->spanner_databaseoperations_get
-    permission spanner_databaseoperations_list = user & role->spanner_databaseoperations_list
-    permission spanner_databaseroles_list = user & role->spanner_databaseroles_list
-    permission spanner_databaseroles_use = user & role->spanner_databaseroles_use
-    permission spanner_databases_beginorrollbackreadwritetransaction = user & role->spanner_databases_beginorrollbackreadwritetransaction
-    permission spanner_databases_beginpartitioneddmltransaction = user & role->spanner_databases_beginpartitioneddmltransaction
-    permission spanner_databases_beginreadonlytransaction = user & role->spanner_databases_beginreadonlytransaction
-    permission spanner_databases_create = user & role->spanner_databases_create
-    permission spanner_databases_drop = user & role->spanner_databases_drop
-    permission spanner_databases_get = user & role->spanner_databases_get
-    permission spanner_databases_getddl = user & role->spanner_databases_getddl
-    permission spanner_databases_getiampolicy = user & role->spanner_databases_getiampolicy
-    permission spanner_databases_list = user & role->spanner_databases_list
-    permission spanner_databases_partitionquery = user & role->spanner_databases_partitionquery
-    permission spanner_databases_partitionread = user & role->spanner_databases_partitionread
-    permission spanner_databases_read = user & role->spanner_databases_read
-    permission spanner_databases_select = user & role->spanner_databases_select
-    permission spanner_databases_setiampolicy = user & role->spanner_databases_setiampolicy
-    permission spanner_databases_update = user & role->spanner_databases_update
-    permission spanner_databases_updateddl = user & role->spanner_databases_updateddl
-    permission spanner_databases_userolebasedaccess = user & role->spanner_databases_userolebasedaccess
-    permission spanner_databases_write = user & role->spanner_databases_write
-    permission spanner_instances_get = user & role->spanner_instances_get
-    permission spanner_instances_getiampolicy = user & role->spanner_instances_getiampolicy
-    permission spanner_instances_list = user & role->spanner_instances_list
-    permission spanner_sessions_create = user & role->spanner_sessions_create
-    permission spanner_sessions_delete = user & role->spanner_sessions_delete
-    permission spanner_sessions_get = user & role->spanner_sessions_get
-    permission spanner_sessions_list = user & role->spanner_sessions_list
+    permission can_spanner_databaseoperations_cancel = spanner_databaseoperations_cancel->bound_user
+    permission can_spanner_databaseoperations_delete = spanner_databaseoperations_delete->bound_user
+    permission can_spanner_databaseoperations_get = spanner_databaseoperations_get->bound_user
+    permission can_spanner_databaseoperations_list = spanner_databaseoperations_list->bound_user
+    permission can_spanner_databaseroles_list = spanner_databaseroles_list->bound_user
+    permission can_spanner_databaseroles_use = spanner_databaseroles_use->bound_user
+    permission can_spanner_databases_beginorrollbackreadwritetransaction = spanner_databases_beginorrollbackreadwritetransaction->bound_user
+    permission can_spanner_databases_beginpartitioneddmltransaction = spanner_databases_beginpartitioneddmltransaction->bound_user
+    permission can_spanner_databases_beginreadonlytransaction = spanner_databases_beginreadonlytransaction->bound_user
+    permission can_spanner_databases_create = spanner_databases_create->bound_user
+    permission can_spanner_databases_drop = spanner_databases_drop->bound_user
+    permission can_spanner_databases_get = spanner_databases_get->bound_user
+    permission can_spanner_databases_getddl = spanner_databases_getddl->bound_user
+    permission can_spanner_databases_getiampolicy = spanner_databases_getiampolicy->bound_user
+    permission can_spanner_databases_list = spanner_databases_list->bound_user
+    permission can_spanner_databases_partitionquery = spanner_databases_partitionquery->bound_user
+    permission can_spanner_databases_partitionread = spanner_databases_partitionread->bound_user
+    permission can_spanner_databases_read = spanner_databases_read->bound_user
+    permission can_spanner_databases_select = spanner_databases_select->bound_user
+    permission can_spanner_databases_setiampolicy = spanner_databases_setiampolicy->bound_user
+    permission can_spanner_databases_update = spanner_databases_update->bound_user
+    permission can_spanner_databases_updateddl = spanner_databases_updateddl->bound_user
+    permission can_spanner_databases_userolebasedaccess = spanner_databases_userolebasedaccess->bound_user
+    permission can_spanner_databases_write = spanner_databases_write->bound_user
+    permission can_spanner_instances_get = spanner_instances_get->bound_user
+    permission can_spanner_instances_getiampolicy = spanner_instances_getiampolicy->bound_user
+    permission can_spanner_instances_list = spanner_instances_list->bound_user
+    permission can_spanner_sessions_create = spanner_sessions_create->bound_user
+    permission can_spanner_sessions_delete = spanner_sessions_delete->bound_user
+    permission can_spanner_sessions_get = spanner_sessions_get->bound_user
+    permission can_spanner_sessions_list = spanner_sessions_list->bound_user
 }
 
 definition project {
-    relation granted: role_binding
+    relation granted: role
 
     // Synthetic Instance Relations
-    permission granted_spanner_instances_get = granted->spanner_instances_get
-    permission granted_spanner_instances_getiampolicy = granted->spanner_instances_getiampolicy
-    permission granted_spanner_instances_list = granted->spanner_instances_list
+    permission granted_spanner_instances_get = granted->can_spanner_instances_get
+    permission granted_spanner_instances_getiampolicy = granted->can_spanner_instances_getiampolicy
+    permission granted_spanner_instances_list = granted->can_spanner_instances_list
 
     // Synthetic Database Relations
-    permission granted_spanner_databases_beginorrollbackreadwritetransaction = granted->spanner_databases_beginorrollbackreadwritetransaction
-    permission granted_spanner_databases_beginpartitioneddmltransaction = granted->spanner_databases_beginpartitioneddmltransaction
-    permission granted_spanner_databases_beginreadonlytransaction = granted->spanner_databases_beginreadonlytransaction
-    permission granted_spanner_databases_create = granted->spanner_databases_create
-    permission granted_spanner_databases_drop = granted->spanner_databases_drop
-    permission granted_spanner_databases_get = granted->spanner_databases_get
-    permission granted_spanner_databases_getddl = granted->spanner_databases_getddl
-    permission granted_spanner_databases_getiampolicy = granted->spanner_databases_getiampolicy
-    permission granted_spanner_databases_list = granted->spanner_databases_list
-    permission granted_spanner_databases_partitionquery = granted->spanner_databases_partitionquery
-    permission granted_spanner_databases_partitionread = granted->spanner_databases_partitionread
-    permission granted_spanner_databases_read = granted->spanner_databases_read
-    permission granted_spanner_databases_select = granted->spanner_databases_select
-    permission granted_spanner_databases_setiampolicy = granted->spanner_databases_setiampolicy
-    permission granted_spanner_databases_update = granted->spanner_databases_update
-    permission granted_spanner_databases_updateddl = granted->spanner_databases_updateddl
-    permission granted_spanner_databases_userolebasedaccess = granted->spanner_databases_userolebasedaccess
-    permission granted_spanner_databases_write = granted->spanner_databases_write
+    permission granted_spanner_databases_beginorrollbackreadwritetransaction = granted->can_spanner_databases_beginorrollbackreadwritetransaction
+    permission granted_spanner_databases_beginpartitioneddmltransaction = granted->can_spanner_databases_beginpartitioneddmltransaction
+    permission granted_spanner_databases_beginreadonlytransaction = granted->can_spanner_databases_beginreadonlytransaction
+    permission granted_spanner_databases_create = granted->can_spanner_databases_create
+    permission granted_spanner_databases_drop = granted->can_spanner_databases_drop
+    permission granted_spanner_databases_get = granted->can_spanner_databases_get
+    permission granted_spanner_databases_getddl = granted->can_spanner_databases_getddl
+    permission granted_spanner_databases_getiampolicy = granted->can_spanner_databases_getiampolicy
+    permission granted_spanner_databases_list = granted->can_spanner_databases_list
+    permission granted_spanner_databases_partitionquery = granted->can_spanner_databases_partitionquery
+    permission granted_spanner_databases_partitionread = granted->can_spanner_databases_partitionread
+    permission granted_spanner_databases_read = granted->can_spanner_databases_read
+    permission granted_spanner_databases_select = granted->can_spanner_databases_select
+    permission granted_spanner_databases_setiampolicy = granted->can_spanner_databases_setiampolicy
+    permission granted_spanner_databases_update = granted->can_spanner_databases_update
+    permission granted_spanner_databases_updateddl = granted->can_spanner_databases_updateddl
+    permission granted_spanner_databases_userolebasedaccess = granted->can_spanner_databases_userolebasedaccess
+    permission granted_spanner_databases_write = granted->can_spanner_databases_write
 
     // Synthetic Sessions Relations
-    permission granted_spanner_sessions_create = granted->spanner_sessions_create
-    permission granted_spanner_sessions_delete = granted->spanner_sessions_delete
-    permission granted_spanner_sessions_get = granted->spanner_sessions_get
-    permission granted_spanner_sessions_list = granted->spanner_sessions_list
+    permission granted_spanner_sessions_create = granted->can_spanner_sessions_create
+    permission granted_spanner_sessions_delete = granted->can_spanner_sessions_delete
+    permission granted_spanner_sessions_get = granted->can_spanner_sessions_get
+    permission granted_spanner_sessions_list = granted->can_spanner_sessions_list
 
     // Synthetic Database Operations Relations
-    permission granted_spanner_databaseoperations_cancel = granted->spanner_databaseoperations_cancel
-    permission granted_spanner_databaseoperations_delete = granted->spanner_databaseoperations_delete
-    permission granted_spanner_databaseoperations_get = granted->spanner_databaseoperations_get
-    permission granted_spanner_databaseoperations_list = granted->spanner_databaseoperations_list
+    permission granted_spanner_databaseoperations_cancel = granted->can_spanner_databaseoperations_cancel
+    permission granted_spanner_databaseoperations_delete = granted->can_spanner_databaseoperations_delete
+    permission granted_spanner_databaseoperations_get = granted->can_spanner_databaseoperations_get
+    permission granted_spanner_databaseoperations_list = granted->can_spanner_databaseoperations_list
 
     // Synthetic Database Roles Relations
-    permission granted_spanner_databaseroles_list = granted->spanner_databaseroles_list
-    permission granted_spanner_databaseroles_use = granted->spanner_databaseroles_use
+    permission granted_spanner_databaseroles_list = granted->can_spanner_databaseroles_list
+    permission granted_spanner_databaseroles_use = granted->can_spanner_databaseroles_use
 }
 
 definition spanner_instance {
     relation project: project
-    relation granted: role_binding
+    relation granted: role
 
-    permission get = granted->spanner_instances_get + project->granted_spanner_instances_get
-    permission getiampolicy = granted->spanner_instances_getiampolicy + project->granted_spanner_instances_getiampolicy
-    permission list = granted->spanner_instances_list + project->granted_spanner_instances_list
+    permission get = granted->can_spanner_instances_get + project->granted_spanner_instances_get
+    permission getiampolicy = granted->can_spanner_instances_getiampolicy + project->granted_spanner_instances_getiampolicy
+    permission list = granted->can_spanner_instances_list + project->granted_spanner_instances_list
 
     // Synthetic Database Relations
-    permission granted_spanner_databases_beginorrollbackreadwritetransaction = granted->spanner_databases_beginorrollbackreadwritetransaction + project->granted_spanner_databases_beginorrollbackreadwritetransaction
-    permission granted_spanner_databases_beginpartitioneddmltransaction = granted->spanner_databases_beginpartitioneddmltransaction + project->granted_spanner_databases_beginpartitioneddmltransaction
-    permission granted_spanner_databases_beginreadonlytransaction = granted->spanner_databases_beginreadonlytransaction + project->granted_spanner_databases_beginreadonlytransaction
-    permission granted_spanner_databases_create = granted->spanner_databases_create + project->granted_spanner_databases_create
-    permission granted_spanner_databases_drop = granted->spanner_databases_drop + project->granted_spanner_databases_drop
-    permission granted_spanner_databases_get = granted->spanner_databases_get + project->granted_spanner_databases_get
-    permission granted_spanner_databases_getddl = granted->spanner_databases_getddl + project->granted_spanner_databases_getddl
-    permission granted_spanner_databases_getiampolicy = granted->spanner_databases_getiampolicy + project->granted_spanner_databases_getiampolicy
-    permission granted_spanner_databases_list = granted->spanner_databases_list + project->granted_spanner_databases_list
-    permission granted_spanner_databases_partitionquery = granted->spanner_databases_partitionquery + project->granted_spanner_databases_partitionquery
-    permission granted_spanner_databases_partitionread = granted->spanner_databases_partitionread + project->granted_spanner_databases_partitionread
-    permission granted_spanner_databases_read = granted->spanner_databases_read + project->granted_spanner_databases_read
-    permission granted_spanner_databases_select = granted->spanner_databases_select + project->granted_spanner_databases_select
-    permission granted_spanner_databases_setiampolicy = granted->spanner_databases_setiampolicy + project->granted_spanner_databases_setiampolicy
-    permission granted_spanner_databases_update = granted->spanner_databases_update + project->granted_spanner_databases_update
-    permission granted_spanner_databases_updateddl = granted->spanner_databases_updateddl + project->granted_spanner_databases_updateddl
-    permission granted_spanner_databases_userolebasedaccess = granted->spanner_databases_userolebasedaccess + project->granted_spanner_databases_userolebasedaccess
-    permission granted_spanner_databases_write = granted->spanner_databases_write + project->granted_spanner_databases_write
+    permission granted_spanner_databases_beginorrollbackreadwritetransaction = granted->can_spanner_databases_beginorrollbackreadwritetransaction + project->granted_spanner_databases_beginorrollbackreadwritetransaction
+    permission granted_spanner_databases_beginpartitioneddmltransaction = granted->can_spanner_databases_beginpartitioneddmltransaction + project->granted_spanner_databases_beginpartitioneddmltransaction
+    permission granted_spanner_databases_beginreadonlytransaction = granted->can_spanner_databases_beginreadonlytransaction + project->granted_spanner_databases_beginreadonlytransaction
+    permission granted_spanner_databases_create = granted->can_spanner_databases_create + project->granted_spanner_databases_create
+    permission granted_spanner_databases_drop = granted->can_spanner_databases_drop + project->granted_spanner_databases_drop
+    permission granted_spanner_databases_get = granted->can_spanner_databases_get + project->granted_spanner_databases_get
+    permission granted_spanner_databases_getddl = granted->can_spanner_databases_getddl + project->granted_spanner_databases_getddl
+    permission granted_spanner_databases_getiampolicy = granted->can_spanner_databases_getiampolicy + project->granted_spanner_databases_getiampolicy
+    permission granted_spanner_databases_list = granted->can_spanner_databases_list + project->granted_spanner_databases_list
+    permission granted_spanner_databases_partitionquery = granted->can_spanner_databases_partitionquery + project->granted_spanner_databases_partitionquery
+    permission granted_spanner_databases_partitionread = granted->can_spanner_databases_partitionread + project->granted_spanner_databases_partitionread
+    permission granted_spanner_databases_read = granted->can_spanner_databases_read + project->granted_spanner_databases_read
+    permission granted_spanner_databases_select = granted->can_spanner_databases_select + project->granted_spanner_databases_select
+    permission granted_spanner_databases_setiampolicy = granted->can_spanner_databases_setiampolicy + project->granted_spanner_databases_setiampolicy
+    permission granted_spanner_databases_update = granted->can_spanner_databases_update + project->granted_spanner_databases_update
+    permission granted_spanner_databases_updateddl = granted->can_spanner_databases_updateddl + project->granted_spanner_databases_updateddl
+    permission granted_spanner_databases_userolebasedaccess = granted->can_spanner_databases_userolebasedaccess + project->granted_spanner_databases_userolebasedaccess
+    permission granted_spanner_databases_write = granted->can_spanner_databases_write + project->granted_spanner_databases_write
 
     // Synthetic Sessions Relations
-    permission granted_spanner_sessions_create = granted->spanner_sessions_create + project->granted_spanner_sessions_create
-    permission granted_spanner_sessions_delete = granted->spanner_sessions_delete + project->granted_spanner_sessions_delete
-    permission granted_spanner_sessions_get = granted->spanner_sessions_get + project->granted_spanner_sessions_get
-    permission granted_spanner_sessions_list = granted->spanner_sessions_list + project->granted_spanner_sessions_list
+    permission granted_spanner_sessions_create = granted->can_spanner_sessions_create + project->granted_spanner_sessions_create
+    permission granted_spanner_sessions_delete = granted->can_spanner_sessions_delete + project->granted_spanner_sessions_delete
+    permission granted_spanner_sessions_get = granted->can_spanner_sessions_get + project->granted_spanner_sessions_get
+    permission granted_spanner_sessions_list = granted->can_spanner_sessions_list + project->granted_spanner_sessions_list
 
     // Synthetic Database Operations Relations
-    permission granted_spanner_databaseoperations_cancel = granted->spanner_databaseoperations_cancel + project->granted_spanner_databaseoperations_cancel
-    permission granted_spanner_databaseoperations_delete = granted->spanner_databaseoperations_delete + project->granted_spanner_databaseoperations_delete
-    permission granted_spanner_databaseoperations_get = granted->spanner_databaseoperations_get + project->granted_spanner_databaseoperations_get
-    permission granted_spanner_databaseoperations_list = granted->spanner_databaseoperations_list + project->granted_spanner_databaseoperations_list
+    permission granted_spanner_databaseoperations_cancel = granted->can_spanner_databaseoperations_cancel + project->granted_spanner_databaseoperations_cancel
+    permission granted_spanner_databaseoperations_delete = granted->can_spanner_databaseoperations_delete + project->granted_spanner_databaseoperations_delete
+    permission granted_spanner_databaseoperations_get = granted->can_spanner_databaseoperations_get + project->granted_spanner_databaseoperations_get
+    permission granted_spanner_databaseoperations_list = granted->can_spanner_databaseoperations_list + project->granted_spanner_databaseoperations_list
 
     // Synthetic Database Roles Relations
-    permission granted_spanner_databaseroles_list = granted->spanner_databaseroles_list + project->granted_spanner_databaseroles_list
-    permission granted_spanner_databaseroles_use = granted->spanner_databaseroles_use + project->granted_spanner_databaseroles_use
+    permission granted_spanner_databaseroles_list = granted->can_spanner_databaseroles_list + project->granted_spanner_databaseroles_list
+    permission granted_spanner_databaseroles_use = granted->can_spanner_databaseroles_use + project->granted_spanner_databaseroles_use
 }
 
 definition spanner_database {
     relation instance: spanner_instance
-    relation granted: role_binding
+    relation granted: role
 
     // Database
-    permission beginorrollbackreadwritetransaction = granted->spanner_databases_beginorrollbackreadwritetransaction + instance->granted_spanner_databases_beginorrollbackreadwritetransaction
-    permission beginpartitioneddmltransaction = granted->spanner_databases_beginpartitioneddmltransaction + instance->granted_spanner_databases_beginpartitioneddmltransaction
-    permission beginreadonlytransaction = granted->spanner_databases_beginreadonlytransaction + instance->granted_spanner_databases_beginreadonlytransaction
-    permission create = granted->spanner_databases_create + instance->granted_spanner_databases_create
-    permission drop = granted->spanner_databases_drop + instance->granted_spanner_databases_drop
-    permission get = granted->spanner_databases_get + instance->granted_spanner_databases_get
-    permission get_ddl = granted->spanner_databases_getddl + instance->granted_spanner_databases_getddl
-    permission getiampolicy = granted->spanner_databases_getiampolicy + instance->granted_spanner_databases_getiampolicy
-    permission list = granted->spanner_databases_list + instance->granted_spanner_databases_list
-    permission partitionquery = granted->spanner_databases_partitionquery + instance->granted_spanner_databases_partitionquery
-    permission partitionread = granted->spanner_databases_partitionread + instance->granted_spanner_databases_partitionread
-    permission read = granted->spanner_databases_read + instance->granted_spanner_databases_read
-    permission select = granted->spanner_databases_select + instance->granted_spanner_databases_select
-    permission setiampolicy = granted->spanner_databases_setiampolicy + instance->granted_spanner_databases_setiampolicy
-    permission update = granted->spanner_databases_update + instance->granted_spanner_databases_update
-    permission updateddl = granted->spanner_databases_updateddl + instance->granted_spanner_databases_updateddl
-    permission userolebasedaccess = granted->spanner_databases_userolebasedaccess + instance->granted_spanner_databases_userolebasedaccess
-    permission write = granted->spanner_databases_write + instance->granted_spanner_databases_write
+    permission beginorrollbackreadwritetransaction = granted->can_spanner_databases_beginorrollbackreadwritetransaction + instance->granted_spanner_databases_beginorrollbackreadwritetransaction
+    permission beginpartitioneddmltransaction = granted->can_spanner_databases_beginpartitioneddmltransaction + instance->granted_spanner_databases_beginpartitioneddmltransaction
+    permission beginreadonlytransaction = granted->can_spanner_databases_beginreadonlytransaction + instance->granted_spanner_databases_beginreadonlytransaction
+    permission create = granted->can_spanner_databases_create + instance->granted_spanner_databases_create
+    permission drop = granted->can_spanner_databases_drop + instance->granted_spanner_databases_drop
+    permission get = granted->can_spanner_databases_get + instance->granted_spanner_databases_get
+    permission get_ddl = granted->can_spanner_databases_getddl + instance->granted_spanner_databases_getddl
+    permission getiampolicy = granted->can_spanner_databases_getiampolicy + instance->granted_spanner_databases_getiampolicy
+    permission list = granted->can_spanner_databases_list + instance->granted_spanner_databases_list
+    permission partitionquery = granted->can_spanner_databases_partitionquery + instance->granted_spanner_databases_partitionquery
+    permission partitionread = granted->can_spanner_databases_partitionread + instance->granted_spanner_databases_partitionread
+    permission read = granted->can_spanner_databases_read + instance->granted_spanner_databases_read
+    permission select = granted->can_spanner_databases_select + instance->granted_spanner_databases_select
+    permission setiampolicy = granted->can_spanner_databases_setiampolicy + instance->granted_spanner_databases_setiampolicy
+    permission update = granted->can_spanner_databases_update + instance->granted_spanner_databases_update
+    permission updateddl = granted->can_spanner_databases_updateddl + instance->granted_spanner_databases_updateddl
+    permission userolebasedaccess = granted->can_spanner_databases_userolebasedaccess + instance->granted_spanner_databases_userolebasedaccess
+    permission write = granted->can_spanner_databases_write + instance->granted_spanner_databases_write
 
     // Sessions
-    permission create_session = granted->spanner_sessions_create + instance->granted_spanner_sessions_create
-    permission delete_session = granted->spanner_sessions_delete + instance->granted_spanner_sessions_delete
-    permission get_session = granted->spanner_sessions_get + instance->granted_spanner_sessions_get
-    permission list_sessions = granted->spanner_sessions_list + instance->granted_spanner_sessions_list
+    permission create_session = granted->can_spanner_sessions_create + instance->granted_spanner_sessions_create
+    permission delete_session = granted->can_spanner_sessions_delete + instance->granted_spanner_sessions_delete
+    permission get_session = granted->can_spanner_sessions_get + instance->granted_spanner_sessions_get
+    permission list_sessions = granted->can_spanner_sessions_list + instance->granted_spanner_sessions_list
 
     // Database Operations
-    permission cancel_operation = granted->spanner_databaseoperations_cancel + instance->granted_spanner_databaseoperations_cancel
-    permission delete_operation = granted->spanner_databaseoperations_delete + instance->granted_spanner_databaseoperations_delete
-    permission get_operation = granted->spanner_databaseoperations_get + instance->granted_spanner_databaseoperations_get
-    permission list_operations = granted->spanner_databaseoperations_list + instance->granted_spanner_databaseoperations_list
+    permission cancel_operation = granted->can_spanner_databaseoperations_cancel + instance->granted_spanner_databaseoperations_cancel
+    permission delete_operation = granted->can_spanner_databaseoperations_delete + instance->granted_spanner_databaseoperations_delete
+    permission get_operation = granted->can_spanner_databaseoperations_get + instance->granted_spanner_databaseoperations_get
+    permission list_operations = granted->can_spanner_databaseoperations_list + instance->granted_spanner_databaseoperations_list
 
     // Database Roles
-    permission list_roles = granted->spanner_databaseroles_list + instance->granted_spanner_databaseroles_list
-    permission use_role = granted->spanner_databaseroles_use + instance->granted_spanner_databaseroles_use
+    permission list_roles = granted->can_spanner_databaseroles_list + instance->granted_spanner_databaseroles_list
+    permission use_role = granted->can_spanner_databaseroles_use + instance->granted_spanner_databaseroles_use
 }
 ```

--- a/schemas/google-iam/schema-and-data.yaml
+++ b/schemas/google-iam/schema-and-data.yaml
@@ -3,267 +3,265 @@ schema: |
   definition user {}
 
   definition role {
-      relation spanner_databaseoperations_cancel: user:*
-      relation spanner_databaseoperations_delete: user:*
-      relation spanner_databaseoperations_get: user:*
-      relation spanner_databaseoperations_list: user:*
-      relation spanner_databaseroles_list: user:*
-      relation spanner_databaseroles_use: user:*
-      relation spanner_databases_beginorrollbackreadwritetransaction: user:*
-      relation spanner_databases_beginpartitioneddmltransaction: user:*
-      relation spanner_databases_beginreadonlytransaction: user:*
-      relation spanner_databases_create: user:*
-      relation spanner_databases_drop: user:*
-      relation spanner_databases_get: user:*
-      relation spanner_databases_getddl: user:*
-      relation spanner_databases_getiampolicy: user:*
-      relation spanner_databases_list: user:*
-      relation spanner_databases_partitionquery: user:*
-      relation spanner_databases_partitionread: user:*
-      relation spanner_databases_read: user:*
-      relation spanner_databases_select: user:*
-      relation spanner_databases_setiampolicy: user:*
-      relation spanner_databases_update: user:*
-      relation spanner_databases_updateddl: user:*
-      relation spanner_databases_userolebasedaccess: user:*
-      relation spanner_databases_write: user:*
-      relation spanner_instances_get: user:*
-      relation spanner_instances_getiampolicy: user:*
-      relation spanner_instances_list: user:*
-      relation spanner_sessions_create: user:*
-      relation spanner_sessions_delete: user:*
-      relation spanner_sessions_get: user:*
-      relation spanner_sessions_list: user:*
-  }
+      relation bound_user: user
 
-  definition role_binding {
-      relation user: user
-      relation role: role
+      relation spanner_databaseoperations_cancel: role
+      relation spanner_databaseoperations_delete: role
+      relation spanner_databaseoperations_get: role
+      relation spanner_databaseoperations_list: role
+      relation spanner_databaseroles_list: role
+      relation spanner_databaseroles_use: role
+      relation spanner_databases_beginorrollbackreadwritetransaction: role
+      relation spanner_databases_beginpartitioneddmltransaction: role
+      relation spanner_databases_beginreadonlytransaction: role
+      relation spanner_databases_create: role
+      relation spanner_databases_drop: role
+      relation spanner_databases_get: role
+      relation spanner_databases_getddl: role
+      relation spanner_databases_getiampolicy: role
+      relation spanner_databases_list: role
+      relation spanner_databases_partitionquery: role
+      relation spanner_databases_partitionread: role
+      relation spanner_databases_read: role
+      relation spanner_databases_select: role
+      relation spanner_databases_setiampolicy: role
+      relation spanner_databases_update: role
+      relation spanner_databases_updateddl: role
+      relation spanner_databases_userolebasedaccess: role
+      relation spanner_databases_write: role
+      relation spanner_instances_get: role
+      relation spanner_instances_getiampolicy: role
+      relation spanner_instances_list: role
+      relation spanner_sessions_create: role
+      relation spanner_sessions_delete: role
+      relation spanner_sessions_get: role
+      relation spanner_sessions_list: role
 
-      permission spanner_databaseoperations_cancel = user & role->spanner_databaseoperations_cancel
-      permission spanner_databaseoperations_delete = user & role->spanner_databaseoperations_delete
-      permission spanner_databaseoperations_get = user & role->spanner_databaseoperations_get
-      permission spanner_databaseoperations_list = user & role->spanner_databaseoperations_list
-      permission spanner_databaseroles_list = user & role->spanner_databaseroles_list
-      permission spanner_databaseroles_use = user & role->spanner_databaseroles_use
-      permission spanner_databases_beginorrollbackreadwritetransaction = user & role->spanner_databases_beginorrollbackreadwritetransaction
-      permission spanner_databases_beginpartitioneddmltransaction = user & role->spanner_databases_beginpartitioneddmltransaction
-      permission spanner_databases_beginreadonlytransaction = user & role->spanner_databases_beginreadonlytransaction
-      permission spanner_databases_create = user & role->spanner_databases_create
-      permission spanner_databases_drop = user & role->spanner_databases_drop
-      permission spanner_databases_get = user & role->spanner_databases_get
-      permission spanner_databases_getddl = user & role->spanner_databases_getddl
-      permission spanner_databases_getiampolicy = user & role->spanner_databases_getiampolicy
-      permission spanner_databases_list = user & role->spanner_databases_list
-      permission spanner_databases_partitionquery = user & role->spanner_databases_partitionquery
-      permission spanner_databases_partitionread = user & role->spanner_databases_partitionread
-      permission spanner_databases_read = user & role->spanner_databases_read
-      permission spanner_databases_select = user & role->spanner_databases_select
-      permission spanner_databases_setiampolicy = user & role->spanner_databases_setiampolicy
-      permission spanner_databases_update = user & role->spanner_databases_update
-      permission spanner_databases_updateddl = user & role->spanner_databases_updateddl
-      permission spanner_databases_userolebasedaccess = user & role->spanner_databases_userolebasedaccess
-      permission spanner_databases_write = user & role->spanner_databases_write
-      permission spanner_instances_get = user & role->spanner_instances_get
-      permission spanner_instances_getiampolicy = user & role->spanner_instances_getiampolicy
-      permission spanner_instances_list = user & role->spanner_instances_list
-      permission spanner_sessions_create = user & role->spanner_sessions_create
-      permission spanner_sessions_delete = user & role->spanner_sessions_delete
-      permission spanner_sessions_get = user & role->spanner_sessions_get
-      permission spanner_sessions_list = user & role->spanner_sessions_list
+      permission can_spanner_databaseoperations_cancel = spanner_databaseoperations_cancel->bound_user
+      permission can_spanner_databaseoperations_delete = spanner_databaseoperations_delete->bound_user
+      permission can_spanner_databaseoperations_get = spanner_databaseoperations_get->bound_user
+      permission can_spanner_databaseoperations_list = spanner_databaseoperations_list->bound_user
+      permission can_spanner_databaseroles_list = spanner_databaseroles_list->bound_user
+      permission can_spanner_databaseroles_use = spanner_databaseroles_use->bound_user
+      permission can_spanner_databases_beginorrollbackreadwritetransaction = spanner_databases_beginorrollbackreadwritetransaction->bound_user
+      permission can_spanner_databases_beginpartitioneddmltransaction = spanner_databases_beginpartitioneddmltransaction->bound_user
+      permission can_spanner_databases_beginreadonlytransaction = spanner_databases_beginreadonlytransaction->bound_user
+      permission can_spanner_databases_create = spanner_databases_create->bound_user
+      permission can_spanner_databases_drop = spanner_databases_drop->bound_user
+      permission can_spanner_databases_get = spanner_databases_get->bound_user
+      permission can_spanner_databases_getddl = spanner_databases_getddl->bound_user
+      permission can_spanner_databases_getiampolicy = spanner_databases_getiampolicy->bound_user
+      permission can_spanner_databases_list = spanner_databases_list->bound_user
+      permission can_spanner_databases_partitionquery = spanner_databases_partitionquery->bound_user
+      permission can_spanner_databases_partitionread = spanner_databases_partitionread->bound_user
+      permission can_spanner_databases_read = spanner_databases_read->bound_user
+      permission can_spanner_databases_select = spanner_databases_select->bound_user
+      permission can_spanner_databases_setiampolicy = spanner_databases_setiampolicy->bound_user
+      permission can_spanner_databases_update = spanner_databases_update->bound_user
+      permission can_spanner_databases_updateddl = spanner_databases_updateddl->bound_user
+      permission can_spanner_databases_userolebasedaccess = spanner_databases_userolebasedaccess->bound_user
+      permission can_spanner_databases_write = spanner_databases_write->bound_user
+      permission can_spanner_instances_get = spanner_instances_get->bound_user
+      permission can_spanner_instances_getiampolicy = spanner_instances_getiampolicy->bound_user
+      permission can_spanner_instances_list = spanner_instances_list->bound_user
+      permission can_spanner_sessions_create = spanner_sessions_create->bound_user
+      permission can_spanner_sessions_delete = spanner_sessions_delete->bound_user
+      permission can_spanner_sessions_get = spanner_sessions_get->bound_user
+      permission can_spanner_sessions_list = spanner_sessions_list->bound_user
   }
 
   definition project {
-      relation granted: role_binding
+      relation granted: role
 
       // Synthetic Instance Relations
-      permission granted_spanner_instances_get = granted->spanner_instances_get
-      permission granted_spanner_instances_getiampolicy = granted->spanner_instances_getiampolicy
-      permission granted_spanner_instances_list = granted->spanner_instances_list
+      permission granted_spanner_instances_get = granted->can_spanner_instances_get
+      permission granted_spanner_instances_getiampolicy = granted->can_spanner_instances_getiampolicy
+      permission granted_spanner_instances_list = granted->can_spanner_instances_list
 
       // Synthetic Database Relations
-      permission granted_spanner_databases_beginorrollbackreadwritetransaction = granted->spanner_databases_beginorrollbackreadwritetransaction
-      permission granted_spanner_databases_beginpartitioneddmltransaction = granted->spanner_databases_beginpartitioneddmltransaction
-      permission granted_spanner_databases_beginreadonlytransaction = granted->spanner_databases_beginreadonlytransaction
-      permission granted_spanner_databases_create = granted->spanner_databases_create
-      permission granted_spanner_databases_drop = granted->spanner_databases_drop
-      permission granted_spanner_databases_get = granted->spanner_databases_get
-      permission granted_spanner_databases_getddl = granted->spanner_databases_getddl
-      permission granted_spanner_databases_getiampolicy = granted->spanner_databases_getiampolicy
-      permission granted_spanner_databases_list = granted->spanner_databases_list
-      permission granted_spanner_databases_partitionquery = granted->spanner_databases_partitionquery
-      permission granted_spanner_databases_partitionread = granted->spanner_databases_partitionread
-      permission granted_spanner_databases_read = granted->spanner_databases_read
-      permission granted_spanner_databases_select = granted->spanner_databases_select
-      permission granted_spanner_databases_setiampolicy = granted->spanner_databases_setiampolicy
-      permission granted_spanner_databases_update = granted->spanner_databases_update
-      permission granted_spanner_databases_updateddl = granted->spanner_databases_updateddl
-      permission granted_spanner_databases_userolebasedaccess = granted->spanner_databases_userolebasedaccess
-      permission granted_spanner_databases_write = granted->spanner_databases_write
+      permission granted_spanner_databases_beginorrollbackreadwritetransaction = granted->can_spanner_databases_beginorrollbackreadwritetransaction
+      permission granted_spanner_databases_beginpartitioneddmltransaction = granted->can_spanner_databases_beginpartitioneddmltransaction
+      permission granted_spanner_databases_beginreadonlytransaction = granted->can_spanner_databases_beginreadonlytransaction
+      permission granted_spanner_databases_create = granted->can_spanner_databases_create
+      permission granted_spanner_databases_drop = granted->can_spanner_databases_drop
+      permission granted_spanner_databases_get = granted->can_spanner_databases_get
+      permission granted_spanner_databases_getddl = granted->can_spanner_databases_getddl
+      permission granted_spanner_databases_getiampolicy = granted->can_spanner_databases_getiampolicy
+      permission granted_spanner_databases_list = granted->can_spanner_databases_list
+      permission granted_spanner_databases_partitionquery = granted->can_spanner_databases_partitionquery
+      permission granted_spanner_databases_partitionread = granted->can_spanner_databases_partitionread
+      permission granted_spanner_databases_read = granted->can_spanner_databases_read
+      permission granted_spanner_databases_select = granted->can_spanner_databases_select
+      permission granted_spanner_databases_setiampolicy = granted->can_spanner_databases_setiampolicy
+      permission granted_spanner_databases_update = granted->can_spanner_databases_update
+      permission granted_spanner_databases_updateddl = granted->can_spanner_databases_updateddl
+      permission granted_spanner_databases_userolebasedaccess = granted->can_spanner_databases_userolebasedaccess
+      permission granted_spanner_databases_write = granted->can_spanner_databases_write
 
       // Synthetic Sessions Relations
-      permission granted_spanner_sessions_create = granted->spanner_sessions_create
-      permission granted_spanner_sessions_delete = granted->spanner_sessions_delete
-      permission granted_spanner_sessions_get = granted->spanner_sessions_get
-      permission granted_spanner_sessions_list = granted->spanner_sessions_list
+      permission granted_spanner_sessions_create = granted->can_spanner_sessions_create
+      permission granted_spanner_sessions_delete = granted->can_spanner_sessions_delete
+      permission granted_spanner_sessions_get = granted->can_spanner_sessions_get
+      permission granted_spanner_sessions_list = granted->can_spanner_sessions_list
 
       // Synthetic Database Operations Relations
-      permission granted_spanner_databaseoperations_cancel = granted->spanner_databaseoperations_cancel
-      permission granted_spanner_databaseoperations_delete = granted->spanner_databaseoperations_delete
-      permission granted_spanner_databaseoperations_get = granted->spanner_databaseoperations_get
-      permission granted_spanner_databaseoperations_list = granted->spanner_databaseoperations_list
+      permission granted_spanner_databaseoperations_cancel = granted->can_spanner_databaseoperations_cancel
+      permission granted_spanner_databaseoperations_delete = granted->can_spanner_databaseoperations_delete
+      permission granted_spanner_databaseoperations_get = granted->can_spanner_databaseoperations_get
+      permission granted_spanner_databaseoperations_list = granted->can_spanner_databaseoperations_list
 
       // Synthetic Database Roles Relations
-      permission granted_spanner_databaseroles_list = granted->spanner_databaseroles_list
-      permission granted_spanner_databaseroles_use = granted->spanner_databaseroles_use
+      permission granted_spanner_databaseroles_list = granted->can_spanner_databaseroles_list
+      permission granted_spanner_databaseroles_use = granted->can_spanner_databaseroles_use
   }
 
   definition spanner_instance {
       relation project: project
-      relation granted: role_binding
+      relation granted: role
 
-      permission get = granted->spanner_instances_get + project->granted_spanner_instances_get
-      permission getiampolicy = granted->spanner_instances_getiampolicy + project->granted_spanner_instances_getiampolicy
-      permission list = granted->spanner_instances_list + project->granted_spanner_instances_list
+      permission get = granted->can_spanner_instances_get + project->granted_spanner_instances_get
+      permission getiampolicy = granted->can_spanner_instances_getiampolicy + project->granted_spanner_instances_getiampolicy
+      permission list = granted->can_spanner_instances_list + project->granted_spanner_instances_list
 
       // Synthetic Database Relations
-      permission granted_spanner_databases_beginorrollbackreadwritetransaction = granted->spanner_databases_beginorrollbackreadwritetransaction + project->granted_spanner_databases_beginorrollbackreadwritetransaction
-      permission granted_spanner_databases_beginpartitioneddmltransaction = granted->spanner_databases_beginpartitioneddmltransaction + project->granted_spanner_databases_beginpartitioneddmltransaction
-      permission granted_spanner_databases_beginreadonlytransaction = granted->spanner_databases_beginreadonlytransaction + project->granted_spanner_databases_beginreadonlytransaction
-      permission granted_spanner_databases_create = granted->spanner_databases_create + project->granted_spanner_databases_create
-      permission granted_spanner_databases_drop = granted->spanner_databases_drop + project->granted_spanner_databases_drop
-      permission granted_spanner_databases_get = granted->spanner_databases_get + project->granted_spanner_databases_get
-      permission granted_spanner_databases_getddl = granted->spanner_databases_getddl + project->granted_spanner_databases_getddl
-      permission granted_spanner_databases_getiampolicy = granted->spanner_databases_getiampolicy + project->granted_spanner_databases_getiampolicy
-      permission granted_spanner_databases_list = granted->spanner_databases_list + project->granted_spanner_databases_list
-      permission granted_spanner_databases_partitionquery = granted->spanner_databases_partitionquery + project->granted_spanner_databases_partitionquery
-      permission granted_spanner_databases_partitionread = granted->spanner_databases_partitionread + project->granted_spanner_databases_partitionread
-      permission granted_spanner_databases_read = granted->spanner_databases_read + project->granted_spanner_databases_read
-      permission granted_spanner_databases_select = granted->spanner_databases_select + project->granted_spanner_databases_select
-      permission granted_spanner_databases_setiampolicy = granted->spanner_databases_setiampolicy + project->granted_spanner_databases_setiampolicy
-      permission granted_spanner_databases_update = granted->spanner_databases_update + project->granted_spanner_databases_update
-      permission granted_spanner_databases_updateddl = granted->spanner_databases_updateddl + project->granted_spanner_databases_updateddl
-      permission granted_spanner_databases_userolebasedaccess = granted->spanner_databases_userolebasedaccess + project->granted_spanner_databases_userolebasedaccess
-      permission granted_spanner_databases_write = granted->spanner_databases_write + project->granted_spanner_databases_write
+      permission granted_spanner_databases_beginorrollbackreadwritetransaction = granted->can_spanner_databases_beginorrollbackreadwritetransaction + project->granted_spanner_databases_beginorrollbackreadwritetransaction
+      permission granted_spanner_databases_beginpartitioneddmltransaction = granted->can_spanner_databases_beginpartitioneddmltransaction + project->granted_spanner_databases_beginpartitioneddmltransaction
+      permission granted_spanner_databases_beginreadonlytransaction = granted->can_spanner_databases_beginreadonlytransaction + project->granted_spanner_databases_beginreadonlytransaction
+      permission granted_spanner_databases_create = granted->can_spanner_databases_create + project->granted_spanner_databases_create
+      permission granted_spanner_databases_drop = granted->can_spanner_databases_drop + project->granted_spanner_databases_drop
+      permission granted_spanner_databases_get = granted->can_spanner_databases_get + project->granted_spanner_databases_get
+      permission granted_spanner_databases_getddl = granted->can_spanner_databases_getddl + project->granted_spanner_databases_getddl
+      permission granted_spanner_databases_getiampolicy = granted->can_spanner_databases_getiampolicy + project->granted_spanner_databases_getiampolicy
+      permission granted_spanner_databases_list = granted->can_spanner_databases_list + project->granted_spanner_databases_list
+      permission granted_spanner_databases_partitionquery = granted->can_spanner_databases_partitionquery + project->granted_spanner_databases_partitionquery
+      permission granted_spanner_databases_partitionread = granted->can_spanner_databases_partitionread + project->granted_spanner_databases_partitionread
+      permission granted_spanner_databases_read = granted->can_spanner_databases_read + project->granted_spanner_databases_read
+      permission granted_spanner_databases_select = granted->can_spanner_databases_select + project->granted_spanner_databases_select
+      permission granted_spanner_databases_setiampolicy = granted->can_spanner_databases_setiampolicy + project->granted_spanner_databases_setiampolicy
+      permission granted_spanner_databases_update = granted->can_spanner_databases_update + project->granted_spanner_databases_update
+      permission granted_spanner_databases_updateddl = granted->can_spanner_databases_updateddl + project->granted_spanner_databases_updateddl
+      permission granted_spanner_databases_userolebasedaccess = granted->can_spanner_databases_userolebasedaccess + project->granted_spanner_databases_userolebasedaccess
+      permission granted_spanner_databases_write = granted->can_spanner_databases_write + project->granted_spanner_databases_write
 
       // Synthetic Sessions Relations
-      permission granted_spanner_sessions_create = granted->spanner_sessions_create + project->granted_spanner_sessions_create
-      permission granted_spanner_sessions_delete = granted->spanner_sessions_delete + project->granted_spanner_sessions_delete
-      permission granted_spanner_sessions_get = granted->spanner_sessions_get + project->granted_spanner_sessions_get
-      permission granted_spanner_sessions_list = granted->spanner_sessions_list + project->granted_spanner_sessions_list
+      permission granted_spanner_sessions_create = granted->can_spanner_sessions_create + project->granted_spanner_sessions_create
+      permission granted_spanner_sessions_delete = granted->can_spanner_sessions_delete + project->granted_spanner_sessions_delete
+      permission granted_spanner_sessions_get = granted->can_spanner_sessions_get + project->granted_spanner_sessions_get
+      permission granted_spanner_sessions_list = granted->can_spanner_sessions_list + project->granted_spanner_sessions_list
 
       // Synthetic Database Operations Relations
-      permission granted_spanner_databaseoperations_cancel = granted->spanner_databaseoperations_cancel + project->granted_spanner_databaseoperations_cancel
-      permission granted_spanner_databaseoperations_delete = granted->spanner_databaseoperations_delete + project->granted_spanner_databaseoperations_delete
-      permission granted_spanner_databaseoperations_get = granted->spanner_databaseoperations_get + project->granted_spanner_databaseoperations_get
-      permission granted_spanner_databaseoperations_list = granted->spanner_databaseoperations_list + project->granted_spanner_databaseoperations_list
+      permission granted_spanner_databaseoperations_cancel = granted->can_spanner_databaseoperations_cancel + project->granted_spanner_databaseoperations_cancel
+      permission granted_spanner_databaseoperations_delete = granted->can_spanner_databaseoperations_delete + project->granted_spanner_databaseoperations_delete
+      permission granted_spanner_databaseoperations_get = granted->can_spanner_databaseoperations_get + project->granted_spanner_databaseoperations_get
+      permission granted_spanner_databaseoperations_list = granted->can_spanner_databaseoperations_list + project->granted_spanner_databaseoperations_list
 
       // Synthetic Database Roles Relations
-      permission granted_spanner_databaseroles_list = granted->spanner_databaseroles_list + project->granted_spanner_databaseroles_list
-      permission granted_spanner_databaseroles_use = granted->spanner_databaseroles_use + project->granted_spanner_databaseroles_use
+      permission granted_spanner_databaseroles_list = granted->can_spanner_databaseroles_list + project->granted_spanner_databaseroles_list
+      permission granted_spanner_databaseroles_use = granted->can_spanner_databaseroles_use + project->granted_spanner_databaseroles_use
   }
 
   definition spanner_database {
       relation instance: spanner_instance
-      relation granted: role_binding
+      relation granted: role
 
       // Database
-      permission beginorrollbackreadwritetransaction = granted->spanner_databases_beginorrollbackreadwritetransaction + instance->granted_spanner_databases_beginorrollbackreadwritetransaction
-      permission beginpartitioneddmltransaction = granted->spanner_databases_beginpartitioneddmltransaction + instance->granted_spanner_databases_beginpartitioneddmltransaction
-      permission beginreadonlytransaction = granted->spanner_databases_beginreadonlytransaction + instance->granted_spanner_databases_beginreadonlytransaction
-      permission create = granted->spanner_databases_create + instance->granted_spanner_databases_create
-      permission drop = granted->spanner_databases_drop + instance->granted_spanner_databases_drop
-      permission get = granted->spanner_databases_get + instance->granted_spanner_databases_get
-      permission get_ddl = granted->spanner_databases_getddl + instance->granted_spanner_databases_getddl
-      permission getiampolicy = granted->spanner_databases_getiampolicy + instance->granted_spanner_databases_getiampolicy
-      permission list = granted->spanner_databases_list + instance->granted_spanner_databases_list
-      permission partitionquery = granted->spanner_databases_partitionquery + instance->granted_spanner_databases_partitionquery
-      permission partitionread = granted->spanner_databases_partitionread + instance->granted_spanner_databases_partitionread
-      permission read = granted->spanner_databases_read + instance->granted_spanner_databases_read
-      permission select = granted->spanner_databases_select + instance->granted_spanner_databases_select
-      permission setiampolicy = granted->spanner_databases_setiampolicy + instance->granted_spanner_databases_setiampolicy
-      permission update = granted->spanner_databases_update + instance->granted_spanner_databases_update
-      permission updateddl = granted->spanner_databases_updateddl + instance->granted_spanner_databases_updateddl
-      permission userolebasedaccess = granted->spanner_databases_userolebasedaccess + instance->granted_spanner_databases_userolebasedaccess
-      permission write = granted->spanner_databases_write + instance->granted_spanner_databases_write
+      permission beginorrollbackreadwritetransaction = granted->can_spanner_databases_beginorrollbackreadwritetransaction + instance->granted_spanner_databases_beginorrollbackreadwritetransaction
+      permission beginpartitioneddmltransaction = granted->can_spanner_databases_beginpartitioneddmltransaction + instance->granted_spanner_databases_beginpartitioneddmltransaction
+      permission beginreadonlytransaction = granted->can_spanner_databases_beginreadonlytransaction + instance->granted_spanner_databases_beginreadonlytransaction
+      permission create = granted->can_spanner_databases_create + instance->granted_spanner_databases_create
+      permission drop = granted->can_spanner_databases_drop + instance->granted_spanner_databases_drop
+      permission get = granted->can_spanner_databases_get + instance->granted_spanner_databases_get
+      permission get_ddl = granted->can_spanner_databases_getddl + instance->granted_spanner_databases_getddl
+      permission getiampolicy = granted->can_spanner_databases_getiampolicy + instance->granted_spanner_databases_getiampolicy
+      permission list = granted->can_spanner_databases_list + instance->granted_spanner_databases_list
+      permission partitionquery = granted->can_spanner_databases_partitionquery + instance->granted_spanner_databases_partitionquery
+      permission partitionread = granted->can_spanner_databases_partitionread + instance->granted_spanner_databases_partitionread
+      permission read = granted->can_spanner_databases_read + instance->granted_spanner_databases_read
+      permission select = granted->can_spanner_databases_select + instance->granted_spanner_databases_select
+      permission setiampolicy = granted->can_spanner_databases_setiampolicy + instance->granted_spanner_databases_setiampolicy
+      permission update = granted->can_spanner_databases_update + instance->granted_spanner_databases_update
+      permission updateddl = granted->can_spanner_databases_updateddl + instance->granted_spanner_databases_updateddl
+      permission userolebasedaccess = granted->can_spanner_databases_userolebasedaccess + instance->granted_spanner_databases_userolebasedaccess
+      permission write = granted->can_spanner_databases_write + instance->granted_spanner_databases_write
 
       // Sessions
-      permission create_session = granted->spanner_sessions_create + instance->granted_spanner_sessions_create
-      permission delete_session = granted->spanner_sessions_delete + instance->granted_spanner_sessions_delete
-      permission get_session = granted->spanner_sessions_get + instance->granted_spanner_sessions_get
-      permission list_sessions = granted->spanner_sessions_list + instance->granted_spanner_sessions_list
+      permission create_session = granted->can_spanner_sessions_create + instance->granted_spanner_sessions_create
+      permission delete_session = granted->can_spanner_sessions_delete + instance->granted_spanner_sessions_delete
+      permission get_session = granted->can_spanner_sessions_get + instance->granted_spanner_sessions_get
+      permission list_sessions = granted->can_spanner_sessions_list + instance->granted_spanner_sessions_list
 
       // Database Operations
-      permission cancel_operation = granted->spanner_databaseoperations_cancel + instance->granted_spanner_databaseoperations_cancel
-      permission delete_operation = granted->spanner_databaseoperations_delete + instance->granted_spanner_databaseoperations_delete
-      permission get_operation = granted->spanner_databaseoperations_get + instance->granted_spanner_databaseoperations_get
-      permission list_operations = granted->spanner_databaseoperations_list + instance->granted_spanner_databaseoperations_list
+      permission cancel_operation = granted->can_spanner_databaseoperations_cancel + instance->granted_spanner_databaseoperations_cancel
+      permission delete_operation = granted->can_spanner_databaseoperations_delete + instance->granted_spanner_databaseoperations_delete
+      permission get_operation = granted->can_spanner_databaseoperations_get + instance->granted_spanner_databaseoperations_get
+      permission list_operations = granted->can_spanner_databaseoperations_list + instance->granted_spanner_databaseoperations_list
 
       // Database Roles
-      permission list_roles = granted->spanner_databaseroles_list + instance->granted_spanner_databaseroles_list
-      permission use_role = granted->spanner_databaseroles_use + instance->granted_spanner_databaseroles_use
+      permission list_roles = granted->can_spanner_databaseroles_list + instance->granted_spanner_databaseroles_list
+      permission use_role = granted->can_spanner_databaseroles_use + instance->granted_spanner_databaseroles_use
   }
 relationships: |-
   spanner_database:db1#instance@spanner_instance:instance1
   spanner_instance:instance1#project@project:proj1
 
   // Add permissions to "admin" role
-  role:spanner_database_admin#spanner_databases_drop@user:*
-  role:spanner_database_admin#spanner_databaseoperations_cancel@user:*
-  role:spanner_database_admin#spanner_databaseoperations_delete@user:*
-  role:spanner_database_admin#spanner_databaseoperations_get@user:*
-  role:spanner_database_admin#spanner_databaseoperations_list@user:*
-  role:spanner_database_admin#spanner_databaseroles_list@user:*
-  role:spanner_database_admin#spanner_databaseroles_use@user:*
-  role:spanner_database_admin#spanner_databases_beginorrollbackreadwritetransaction@user:*
-  role:spanner_database_admin#spanner_databases_beginpartitioneddmltransaction@user:*
-  role:spanner_database_admin#spanner_databases_beginreadonlytransaction@user:*
-  role:spanner_database_admin#spanner_databases_create@user:*
-  role:spanner_database_admin#spanner_databases_drop@user:*
-  role:spanner_database_admin#spanner_databases_get@user:*
-  role:spanner_database_admin#spanner_databases_getddl@user:*
-  role:spanner_database_admin#spanner_databases_getiampolicy@user:*
-  role:spanner_database_admin#spanner_databases_list@user:*
-  role:spanner_database_admin#spanner_databases_partitionquery@user:*
-  role:spanner_database_admin#spanner_databases_partitionread@user:*
-  role:spanner_database_admin#spanner_databases_read@user:*
-  role:spanner_database_admin#spanner_databases_select@user:*
-  role:spanner_database_admin#spanner_databases_setiampolicy@user:*
-  role:spanner_database_admin#spanner_databases_update@user:*
-  role:spanner_database_admin#spanner_databases_updateddl@user:*
-  role:spanner_database_admin#spanner_databases_userolebasedaccess@user:*
-  role:spanner_database_admin#spanner_databases_write@user:*
-  role:spanner_database_admin#spanner_instances_get@user:*
-  role:spanner_database_admin#spanner_instances_getiampolicy@user:*
-  role:spanner_database_admin#spanner_instances_list@user:*
-  role:spanner_database_admin#spanner_sessions_create@user:*
-  role:spanner_database_admin#spanner_sessions_delete@user:*
-  role:spanner_database_admin#spanner_sessions_get@user:*
-  role:spanner_database_admin#spanner_sessions_list@user:*
+  role:spanner_database_admin#spanner_databases_drop@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databaseoperations_cancel@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databaseoperations_delete@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databaseoperations_get@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databaseoperations_list@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databaseroles_list@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databaseroles_use@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_beginorrollbackreadwritetransaction@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_beginpartitioneddmltransaction@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_beginreadonlytransaction@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_create@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_drop@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_get@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_getddl@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_getiampolicy@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_list@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_partitionquery@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_partitionread@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_read@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_select@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_setiampolicy@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_update@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_updateddl@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_userolebasedaccess@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_write@role:spanner_database_admin
+  role:spanner_database_admin#spanner_instances_get@role:spanner_database_admin
+  role:spanner_database_admin#spanner_instances_getiampolicy@role:spanner_database_admin
+  role:spanner_database_admin#spanner_instances_list@role:spanner_database_admin
+  role:spanner_database_admin#spanner_sessions_create@role:spanner_database_admin
+  role:spanner_database_admin#spanner_sessions_delete@role:spanner_database_admin
+  role:spanner_database_admin#spanner_sessions_get@role:spanner_database_admin
+  role:spanner_database_admin#spanner_sessions_list@role:spanner_database_admin
 
   // Add permissions to "reader" role
-  role:spanner_database_reader#spanner_databases_beginreadonlytransaction@user:*
-  role:spanner_database_reader#spanner_databases_getddl@user:*
-  role:spanner_database_reader#spanner_databases_partitionquery@user:*
-  role:spanner_database_reader#spanner_databases_partitionread@user:*
-  role:spanner_database_reader#spanner_databases_read@user:*
-  role:spanner_database_reader#spanner_databases_select@user:*
-  role:spanner_database_reader#spanner_instances_get@user:*
-  role:spanner_database_reader#spanner_sessions_create@user:*
-  role:spanner_database_reader#spanner_sessions_delete@user:*
-  role:spanner_database_reader#spanner_sessions_get@user:*
-  role:spanner_database_reader#spanner_sessions_list@user:*
+  role:spanner_database_reader#spanner_databases_beginreadonlytransaction@role:spanner_database_reader
+  role:spanner_database_reader#spanner_databases_getddl@role:spanner_database_reader
+  role:spanner_database_reader#spanner_databases_partitionquery@role:spanner_database_reader
+  role:spanner_database_reader#spanner_databases_partitionread@role:spanner_database_reader
+  role:spanner_database_reader#spanner_databases_read@role:spanner_database_reader
+  role:spanner_database_reader#spanner_databases_select@role:spanner_database_reader
+  role:spanner_database_reader#spanner_instances_get@role:spanner_database_reader
+  role:spanner_database_reader#spanner_sessions_create@role:spanner_database_reader
+  role:spanner_database_reader#spanner_sessions_delete@role:spanner_database_reader
+  role:spanner_database_reader#spanner_sessions_get@role:spanner_database_reader
+  role:spanner_database_reader#spanner_sessions_list@role:spanner_database_reader
 
   // Grant a role to a specific user on a resource
-  role_binding:specific_db_admin_binding#role@role:spanner_database_admin
-  role_binding:specific_db_admin_binding#user@user:specific_db_admin
-  spanner_database:db1#granted@role_binding:specific_db_admin_binding
-  role_binding:project_db_reader_binding#role@role:spanner_database_reader
-  role_binding:project_db_reader_binding#user@user:project_db_reader
-  project:proj1#granted@role_binding:project_db_reader_binding
+  role:spanner_database_admin#bound_user@user:specific_db_admin
+  spanner_database:db1#granted@role:spanner_database_admin
+  role:spanner_database_reader#bound_user@user:project_db_reader
+  project:proj1#granted@role:spanner_database_reader
+assertions:
+  assertTrue: []
+  assertFalse: []
 validation:
   spanner_database:db1#drop:
-    - "[user:specific_db_admin] is <role_binding:specific_db_admin_binding#user>"
+    - "[user:specific_db_admin] is <role:spanner_database_admin#bound_user>"
   spanner_database:db1#read:
-    - "[user:project_db_reader] is <role_binding:project_db_reader_binding#user>"
-    - "[user:specific_db_admin] is <role_binding:specific_db_admin_binding#user>"
+    - "[user:project_db_reader] is <role:spanner_database_reader#bound_user>"
+    - "[user:specific_db_admin] is <role:spanner_database_admin#bound_user>"


### PR DESCRIPTION
- uses self relations insted of wildcards
- requires fewer relationships written to bind a role / user / resource together

[Playground Link](https://play.authzed.com/s/aJwak-J5GV9O/schema)