### PR TITLE
Add example of multiple file validation with zed validate

### DIFF
--- a/schemas/multiple-validation-files/README.md
+++ b/schemas/multiple-validation-files/README.md
@@ -1,0 +1,13 @@
+## Multiple Validation Files with a Single Schema
+
+This folder demonstrates a structure for a schema and validation files that
+can be run in a single `zed validate` command and used as a template
+for writing multiple independent tests of a single schema.
+
+Running the following:
+
+```
+zed validate validations/*
+```
+
+in this folder will validate the schema and run all validations in all schema files.

--- a/schemas/multiple-validation-files/README.md
+++ b/schemas/multiple-validation-files/README.md
@@ -11,3 +11,6 @@ zed validate validations/*
 ```
 
 in this folder will validate the schema and run all validations in all schema files.
+
+Note the use of `schemaFile: ` in the validation files - this allows the validation file to
+reference the schema without the schema needing to be inline.

--- a/schemas/multiple-validation-files/schema.zed
+++ b/schemas/multiple-validation-files/schema.zed
@@ -1,0 +1,200 @@
+definition user {}
+
+definition role {
+  relation bound_user: user
+
+  relation spanner_databaseoperations_cancel: role
+  relation spanner_databaseoperations_delete: role
+  relation spanner_databaseoperations_get: role
+  relation spanner_databaseoperations_list: role
+  relation spanner_databaseroles_list: role
+  relation spanner_databaseroles_use: role
+  relation spanner_databases_beginorrollbackreadwritetransaction: role
+  relation spanner_databases_beginpartitioneddmltransaction: role
+  relation spanner_databases_beginreadonlytransaction: role
+  relation spanner_databases_create: role
+  relation spanner_databases_drop: role
+  relation spanner_databases_get: role
+  relation spanner_databases_getddl: role
+  relation spanner_databases_getiampolicy: role
+  relation spanner_databases_list: role
+  relation spanner_databases_partitionquery: role
+  relation spanner_databases_partitionread: role
+  relation spanner_databases_read: role
+  relation spanner_databases_select: role
+  relation spanner_databases_setiampolicy: role
+  relation spanner_databases_update: role
+  relation spanner_databases_updateddl: role
+  relation spanner_databases_userolebasedaccess: role
+  relation spanner_databases_write: role
+  relation spanner_instances_get: role
+  relation spanner_instances_getiampolicy: role
+  relation spanner_instances_list: role
+  relation spanner_sessions_create: role
+  relation spanner_sessions_delete: role
+  relation spanner_sessions_get: role
+  relation spanner_sessions_list: role
+
+  permission can_spanner_databaseoperations_cancel = spanner_databaseoperations_cancel->bound_user
+  permission can_spanner_databaseoperations_delete = spanner_databaseoperations_delete->bound_user
+  permission can_spanner_databaseoperations_get = spanner_databaseoperations_get->bound_user
+  permission can_spanner_databaseoperations_list = spanner_databaseoperations_list->bound_user
+  permission can_spanner_databaseroles_list = spanner_databaseroles_list->bound_user
+  permission can_spanner_databaseroles_use = spanner_databaseroles_use->bound_user
+  permission can_spanner_databases_beginorrollbackreadwritetransaction = spanner_databases_beginorrollbackreadwritetransaction->bound_user
+  permission can_spanner_databases_beginpartitioneddmltransaction = spanner_databases_beginpartitioneddmltransaction->bound_user
+  permission can_spanner_databases_beginreadonlytransaction = spanner_databases_beginreadonlytransaction->bound_user
+  permission can_spanner_databases_create = spanner_databases_create->bound_user
+  permission can_spanner_databases_drop = spanner_databases_drop->bound_user
+  permission can_spanner_databases_get = spanner_databases_get->bound_user
+  permission can_spanner_databases_getddl = spanner_databases_getddl->bound_user
+  permission can_spanner_databases_getiampolicy = spanner_databases_getiampolicy->bound_user
+  permission can_spanner_databases_list = spanner_databases_list->bound_user
+  permission can_spanner_databases_partitionquery = spanner_databases_partitionquery->bound_user
+  permission can_spanner_databases_partitionread = spanner_databases_partitionread->bound_user
+  permission can_spanner_databases_read = spanner_databases_read->bound_user
+  permission can_spanner_databases_select = spanner_databases_select->bound_user
+  permission can_spanner_databases_setiampolicy = spanner_databases_setiampolicy->bound_user
+  permission can_spanner_databases_update = spanner_databases_update->bound_user
+  permission can_spanner_databases_updateddl = spanner_databases_updateddl->bound_user
+  permission can_spanner_databases_userolebasedaccess = spanner_databases_userolebasedaccess->bound_user
+  permission can_spanner_databases_write = spanner_databases_write->bound_user
+  permission can_spanner_instances_get = spanner_instances_get->bound_user
+  permission can_spanner_instances_getiampolicy = spanner_instances_getiampolicy->bound_user
+  permission can_spanner_instances_list = spanner_instances_list->bound_user
+  permission can_spanner_sessions_create = spanner_sessions_create->bound_user
+  permission can_spanner_sessions_delete = spanner_sessions_delete->bound_user
+  permission can_spanner_sessions_get = spanner_sessions_get->bound_user
+  permission can_spanner_sessions_list = spanner_sessions_list->bound_user
+}
+
+definition project {
+  relation granted: role
+
+  // Synthetic Instance Relations
+  permission granted_spanner_instances_get = granted->can_spanner_instances_get
+  permission granted_spanner_instances_getiampolicy = granted->can_spanner_instances_getiampolicy
+  permission granted_spanner_instances_list = granted->can_spanner_instances_list
+
+  // Synthetic Database Relations
+  permission granted_spanner_databases_beginorrollbackreadwritetransaction = granted->can_spanner_databases_beginorrollbackreadwritetransaction
+  permission granted_spanner_databases_beginpartitioneddmltransaction = granted->can_spanner_databases_beginpartitioneddmltransaction
+  permission granted_spanner_databases_beginreadonlytransaction = granted->can_spanner_databases_beginreadonlytransaction
+  permission granted_spanner_databases_create = granted->can_spanner_databases_create
+  permission granted_spanner_databases_drop = granted->can_spanner_databases_drop
+  permission granted_spanner_databases_get = granted->can_spanner_databases_get
+  permission granted_spanner_databases_getddl = granted->can_spanner_databases_getddl
+  permission granted_spanner_databases_getiampolicy = granted->can_spanner_databases_getiampolicy
+  permission granted_spanner_databases_list = granted->can_spanner_databases_list
+  permission granted_spanner_databases_partitionquery = granted->can_spanner_databases_partitionquery
+  permission granted_spanner_databases_partitionread = granted->can_spanner_databases_partitionread
+  permission granted_spanner_databases_read = granted->can_spanner_databases_read
+  permission granted_spanner_databases_select = granted->can_spanner_databases_select
+  permission granted_spanner_databases_setiampolicy = granted->can_spanner_databases_setiampolicy
+  permission granted_spanner_databases_update = granted->can_spanner_databases_update
+  permission granted_spanner_databases_updateddl = granted->can_spanner_databases_updateddl
+  permission granted_spanner_databases_userolebasedaccess = granted->can_spanner_databases_userolebasedaccess
+  permission granted_spanner_databases_write = granted->can_spanner_databases_write
+
+  // Synthetic Sessions Relations
+  permission granted_spanner_sessions_create = granted->can_spanner_sessions_create
+  permission granted_spanner_sessions_delete = granted->can_spanner_sessions_delete
+  permission granted_spanner_sessions_get = granted->can_spanner_sessions_get
+  permission granted_spanner_sessions_list = granted->can_spanner_sessions_list
+
+  // Synthetic Database Operations Relations
+  permission granted_spanner_databaseoperations_cancel = granted->can_spanner_databaseoperations_cancel
+  permission granted_spanner_databaseoperations_delete = granted->can_spanner_databaseoperations_delete
+  permission granted_spanner_databaseoperations_get = granted->can_spanner_databaseoperations_get
+  permission granted_spanner_databaseoperations_list = granted->can_spanner_databaseoperations_list
+
+  // Synthetic Database Roles Relations
+  permission granted_spanner_databaseroles_list = granted->can_spanner_databaseroles_list
+  permission granted_spanner_databaseroles_use = granted->can_spanner_databaseroles_use
+}
+
+definition spanner_instance {
+  relation project: project
+  relation granted: role
+
+  permission get = granted->can_spanner_instances_get + project->granted_spanner_instances_get
+  permission getiampolicy = granted->can_spanner_instances_getiampolicy + project->granted_spanner_instances_getiampolicy
+  permission list = granted->can_spanner_instances_list + project->granted_spanner_instances_list
+
+  // Synthetic Database Relations
+  permission granted_spanner_databases_beginorrollbackreadwritetransaction = granted->can_spanner_databases_beginorrollbackreadwritetransaction + project->granted_spanner_databases_beginorrollbackreadwritetransaction
+  permission granted_spanner_databases_beginpartitioneddmltransaction = granted->can_spanner_databases_beginpartitioneddmltransaction + project->granted_spanner_databases_beginpartitioneddmltransaction
+  permission granted_spanner_databases_beginreadonlytransaction = granted->can_spanner_databases_beginreadonlytransaction + project->granted_spanner_databases_beginreadonlytransaction
+  permission granted_spanner_databases_create = granted->can_spanner_databases_create + project->granted_spanner_databases_create
+  permission granted_spanner_databases_drop = granted->can_spanner_databases_drop + project->granted_spanner_databases_drop
+  permission granted_spanner_databases_get = granted->can_spanner_databases_get + project->granted_spanner_databases_get
+  permission granted_spanner_databases_getddl = granted->can_spanner_databases_getddl + project->granted_spanner_databases_getddl
+  permission granted_spanner_databases_getiampolicy = granted->can_spanner_databases_getiampolicy + project->granted_spanner_databases_getiampolicy
+  permission granted_spanner_databases_list = granted->can_spanner_databases_list + project->granted_spanner_databases_list
+  permission granted_spanner_databases_partitionquery = granted->can_spanner_databases_partitionquery + project->granted_spanner_databases_partitionquery
+  permission granted_spanner_databases_partitionread = granted->can_spanner_databases_partitionread + project->granted_spanner_databases_partitionread
+  permission granted_spanner_databases_read = granted->can_spanner_databases_read + project->granted_spanner_databases_read
+  permission granted_spanner_databases_select = granted->can_spanner_databases_select + project->granted_spanner_databases_select
+  permission granted_spanner_databases_setiampolicy = granted->can_spanner_databases_setiampolicy + project->granted_spanner_databases_setiampolicy
+  permission granted_spanner_databases_update = granted->can_spanner_databases_update + project->granted_spanner_databases_update
+  permission granted_spanner_databases_updateddl = granted->can_spanner_databases_updateddl + project->granted_spanner_databases_updateddl
+  permission granted_spanner_databases_userolebasedaccess = granted->can_spanner_databases_userolebasedaccess + project->granted_spanner_databases_userolebasedaccess
+  permission granted_spanner_databases_write = granted->can_spanner_databases_write + project->granted_spanner_databases_write
+
+  // Synthetic Sessions Relations
+  permission granted_spanner_sessions_create = granted->can_spanner_sessions_create + project->granted_spanner_sessions_create
+  permission granted_spanner_sessions_delete = granted->can_spanner_sessions_delete + project->granted_spanner_sessions_delete
+  permission granted_spanner_sessions_get = granted->can_spanner_sessions_get + project->granted_spanner_sessions_get
+  permission granted_spanner_sessions_list = granted->can_spanner_sessions_list + project->granted_spanner_sessions_list
+
+  // Synthetic Database Operations Relations
+  permission granted_spanner_databaseoperations_cancel = granted->can_spanner_databaseoperations_cancel + project->granted_spanner_databaseoperations_cancel
+  permission granted_spanner_databaseoperations_delete = granted->can_spanner_databaseoperations_delete + project->granted_spanner_databaseoperations_delete
+  permission granted_spanner_databaseoperations_get = granted->can_spanner_databaseoperations_get + project->granted_spanner_databaseoperations_get
+  permission granted_spanner_databaseoperations_list = granted->can_spanner_databaseoperations_list + project->granted_spanner_databaseoperations_list
+
+  // Synthetic Database Roles Relations
+  permission granted_spanner_databaseroles_list = granted->can_spanner_databaseroles_list + project->granted_spanner_databaseroles_list
+  permission granted_spanner_databaseroles_use = granted->can_spanner_databaseroles_use + project->granted_spanner_databaseroles_use
+}
+
+definition spanner_database {
+  relation instance: spanner_instance
+  relation granted: role
+
+  // Database
+  permission beginorrollbackreadwritetransaction = granted->can_spanner_databases_beginorrollbackreadwritetransaction + instance->granted_spanner_databases_beginorrollbackreadwritetransaction
+  permission beginpartitioneddmltransaction = granted->can_spanner_databases_beginpartitioneddmltransaction + instance->granted_spanner_databases_beginpartitioneddmltransaction
+  permission beginreadonlytransaction = granted->can_spanner_databases_beginreadonlytransaction + instance->granted_spanner_databases_beginreadonlytransaction
+  permission create = granted->can_spanner_databases_create + instance->granted_spanner_databases_create
+  permission drop = granted->can_spanner_databases_drop + instance->granted_spanner_databases_drop
+  permission get = granted->can_spanner_databases_get + instance->granted_spanner_databases_get
+  permission get_ddl = granted->can_spanner_databases_getddl + instance->granted_spanner_databases_getddl
+  permission getiampolicy = granted->can_spanner_databases_getiampolicy + instance->granted_spanner_databases_getiampolicy
+  permission list = granted->can_spanner_databases_list + instance->granted_spanner_databases_list
+  permission partitionquery = granted->can_spanner_databases_partitionquery + instance->granted_spanner_databases_partitionquery
+  permission partitionread = granted->can_spanner_databases_partitionread + instance->granted_spanner_databases_partitionread
+  permission read = granted->can_spanner_databases_read + instance->granted_spanner_databases_read
+  permission select = granted->can_spanner_databases_select + instance->granted_spanner_databases_select
+  permission setiampolicy = granted->can_spanner_databases_setiampolicy + instance->granted_spanner_databases_setiampolicy
+  permission update = granted->can_spanner_databases_update + instance->granted_spanner_databases_update
+  permission updateddl = granted->can_spanner_databases_updateddl + instance->granted_spanner_databases_updateddl
+  permission userolebasedaccess = granted->can_spanner_databases_userolebasedaccess + instance->granted_spanner_databases_userolebasedaccess
+  permission write = granted->can_spanner_databases_write + instance->granted_spanner_databases_write
+
+  // Sessions
+  permission create_session = granted->can_spanner_sessions_create + instance->granted_spanner_sessions_create
+  permission delete_session = granted->can_spanner_sessions_delete + instance->granted_spanner_sessions_delete
+  permission get_session = granted->can_spanner_sessions_get + instance->granted_spanner_sessions_get
+  permission list_sessions = granted->can_spanner_sessions_list + instance->granted_spanner_sessions_list
+
+  // Database Operations
+  permission cancel_operation = granted->can_spanner_databaseoperations_cancel + instance->granted_spanner_databaseoperations_cancel
+  permission delete_operation = granted->can_spanner_databaseoperations_delete + instance->granted_spanner_databaseoperations_delete
+  permission get_operation = granted->can_spanner_databaseoperations_get + instance->granted_spanner_databaseoperations_get
+  permission list_operations = granted->can_spanner_databaseoperations_list + instance->granted_spanner_databaseoperations_list
+
+  // Database Roles
+  permission list_roles = granted->can_spanner_databaseroles_list + instance->granted_spanner_databaseroles_list
+  permission use_role = granted->can_spanner_databaseroles_use + instance->granted_spanner_databaseroles_use
+}

--- a/schemas/multiple-validation-files/validations/admin-role.yaml
+++ b/schemas/multiple-validation-files/validations/admin-role.yaml
@@ -1,0 +1,54 @@
+---
+schemaFile: "../schema.zed"
+relationships: |-
+  spanner_database:db1#instance@spanner_instance:instance1
+  spanner_instance:instance1#project@project:proj1
+
+  // Add permissions to "admin" role
+  role:spanner_database_admin#spanner_databaseoperations_cancel@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databaseoperations_delete@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databaseoperations_get@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databaseoperations_list@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databaseroles_list@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databaseroles_use@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_beginorrollbackreadwritetransaction@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_beginpartitioneddmltransaction@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_beginreadonlytransaction@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_create@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_drop@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_get@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_getddl@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_getiampolicy@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_list@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_partitionquery@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_partitionread@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_read@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_select@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_setiampolicy@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_update@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_updateddl@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_userolebasedaccess@role:spanner_database_admin
+  role:spanner_database_admin#spanner_databases_write@role:spanner_database_admin
+  role:spanner_database_admin#spanner_instances_get@role:spanner_database_admin
+  role:spanner_database_admin#spanner_instances_getiampolicy@role:spanner_database_admin
+  role:spanner_database_admin#spanner_instances_list@role:spanner_database_admin
+  role:spanner_database_admin#spanner_sessions_create@role:spanner_database_admin
+  role:spanner_database_admin#spanner_sessions_delete@role:spanner_database_admin
+  role:spanner_database_admin#spanner_sessions_get@role:spanner_database_admin
+  role:spanner_database_admin#spanner_sessions_list@role:spanner_database_admin
+
+  // Grant admin role to a specific user on a resource
+  role:spanner_database_admin#bound_user@user:specific_db_admin
+  spanner_database:db1#granted@role:spanner_database_admin
+assertions:
+  assertTrue:
+    - "spanner_database:db1#drop@user:specific_db_admin"
+    - "spanner_database:db1#delete_session@user:specific_db_admin"
+  assertFalse:
+    # Can't drop a database you don't have access to
+    - "spanner_database:db2#drop@user:specific_db_admin"
+validation:
+  spanner_database:db1#drop:
+    - "[user:specific_db_admin] is <role:spanner_database_admin#bound_user>"
+  spanner_database:db1#read:
+    - "[user:specific_db_admin] is <role:spanner_database_admin#bound_user>"

--- a/schemas/multiple-validation-files/validations/reader-role.yaml
+++ b/schemas/multiple-validation-files/validations/reader-role.yaml
@@ -1,0 +1,32 @@
+---
+schemaFile: "../schema.zed"
+relationships: |-
+  spanner_database:db1#instance@spanner_instance:instance1
+  spanner_instance:instance1#project@project:proj1
+
+  // Add permissions to "reader" role
+  role:spanner_database_reader#spanner_databases_beginreadonlytransaction@role:spanner_database_reader
+  role:spanner_database_reader#spanner_databases_getddl@role:spanner_database_reader
+  role:spanner_database_reader#spanner_databases_partitionquery@role:spanner_database_reader
+  role:spanner_database_reader#spanner_databases_partitionread@role:spanner_database_reader
+  role:spanner_database_reader#spanner_databases_read@role:spanner_database_reader
+  role:spanner_database_reader#spanner_databases_select@role:spanner_database_reader
+  role:spanner_database_reader#spanner_instances_get@role:spanner_database_reader
+  role:spanner_database_reader#spanner_sessions_create@role:spanner_database_reader
+  role:spanner_database_reader#spanner_sessions_delete@role:spanner_database_reader
+  role:spanner_database_reader#spanner_sessions_get@role:spanner_database_reader
+  role:spanner_database_reader#spanner_sessions_list@role:spanner_database_reader
+
+  // Grant reader role to a specific user on a resource
+  role:spanner_database_reader#bound_user@user:project_db_reader
+  project:proj1#granted@role:spanner_database_reader
+assertions:
+  assertTrue:
+    - "spanner_database:db1#read@user:project_db_reader"
+    - "spanner_database:db1#list_sessions@user:project_db_reader"
+  assertFalse:
+    # Can't drop a database you don't have access to
+    - "spanner_database:db2#drop@user:project_db_reader"
+validation:
+  spanner_database:db1#read:
+    - "[user:project_db_reader] is <role:spanner_database_reader#bound_user>"


### PR DESCRIPTION
## Description
This is a newish feature of `zed validate`. It allows for breaking out validation into multiple files, which should make it possible to break down a validation file into multiple independent files and suites.

## Changes
* Add multiple file validation example
## Testing
Review.